### PR TITLE
Main 11864

### DIFF
--- a/csv.go
+++ b/csv.go
@@ -64,52 +64,53 @@ func getCSVReader(in io.Reader) *csv.Reader {
 // Marshal functions
 
 // MarshalFile saves the interface as CSV in the file.
-func MarshalFile(in interface{}, file *os.File, delim rune) (err error) {
-	return Marshal(in, delim, file)
+func MarshalFile(in interface{}, file *os.File) (err error) {
+	return Marshal(in, file)
 }
 
 // MarshalString returns the CSV string from the interface.
-func MarshalString(in interface{}, delim rune) (out string, err error) {
+func MarshalString(in interface{}) (out string, err error) {
 	bufferString := bytes.NewBufferString(out)
-	if err := Marshal(in, delim, bufferString); err != nil {
+	if err := Marshal(in, bufferString); err != nil {
 		return "", err
 	}
 	return bufferString.String(), nil
 }
 
 // MarshalBytes returns the CSV bytes from the interface.
-func MarshalBytes(in interface{}, delim rune) (out []byte, err error) {
+func MarshalBytes(in interface{}) (out []byte, err error) {
 	bufferString := bytes.NewBuffer(out)
-	if err := Marshal(in, delim, bufferString); err != nil {
+	if err := Marshal(in, bufferString); err != nil {
 		return nil, err
 	}
 	return bufferString.Bytes(), nil
 }
 
 // Marshal returns the CSV in writer from the interface.
-func Marshal(in interface{}, delim rune, out io.Writer) (err error) {
-	return newEncoder(out, delim).writeTo(in)
+func Marshal(in interface{}, out io.Writer) (err error) {
+	return newEncoder(out).writeTo(in)
 }
 
 // --------------------------------------------------------------------------
 // Unmarshal functions
 
 // UnmarshalFile parses the CSV from the file in the interface.
-func UnmarshalFile(in *os.File, delim rune, out interface{}) (err error) {
-	return Unmarshal(in, delim, out)
+func UnmarshalFile(in *os.File, out interface{}) (err error) {
+	return Unmarshal(in, out)
 }
 
 // UnmarshalString parses the CSV from the string in the interface.
-func UnmarshalString(in string, delim rune, out interface{}) (err error) {
-	return Unmarshal(strings.NewReader(in), delim, out)
+func UnmarshalString(in string, out interface{}) (err error) {
+	return Unmarshal(strings.NewReader(in), out)
 }
 
 // UnmarshalBytes parses the CSV from the bytes in the interface.
-func UnmarshalBytes(in []byte, delim rune, out interface{}) (err error) {
-	return Unmarshal(bytes.NewReader(in), delim, out)
+func UnmarshalBytes(in []byte, out interface{}) (err error) {
+	return Unmarshal(bytes.NewReader(in), out)
 }
 
 // Unmarshal parses the CSV from the reader in the interface.
-func Unmarshal(in io.Reader, delim rune, out interface{}) (err error) {
-	return newDecoder(in, delim).readTo(out)
+func Unmarshal(in io.Reader, out interface{}) (err error) {
+	return newDecoder(in).readTo(out)
 }
+

--- a/csv.go
+++ b/csv.go
@@ -111,6 +111,9 @@ func UnmarshalBytes(in []byte, out interface{}) (err error) {
 
 // Unmarshal parses the CSV from the reader in the interface.
 func Unmarshal(in io.Reader, out interface{}) (err error) {
-	return newDecoder(in).readTo(out)
+	return readTo(newDecoder(in), out)
 }
 
+func UnmarshalCSV(in *csv.Reader, out interface{}) (err error) {
+	return readTo(csvDecoder{in}, out)
+}

--- a/csv.go
+++ b/csv.go
@@ -88,7 +88,12 @@ func MarshalBytes(in interface{}) (out []byte, err error) {
 
 // Marshal returns the CSV in writer from the interface.
 func Marshal(in interface{}, out io.Writer) (err error) {
-	return newEncoder(out).writeTo(in)
+	writer := getCSVWriter(out)
+	return writeTo(writer, in)
+}
+
+func MarshalCSV(in interface{}, out *csv.Writer) (err error) {
+	return writeTo(out, in)
 }
 
 // --------------------------------------------------------------------------

--- a/csv.go
+++ b/csv.go
@@ -119,6 +119,6 @@ func Unmarshal(in io.Reader, out interface{}) (err error) {
 	return readTo(newDecoder(in), out)
 }
 
-func UnmarshalCSV(in *csv.Reader, out interface{}) (err error) {
+func UnmarshalCSV(in *csv.Reader, out interface{}) error {
 	return readTo(csvDecoder{in}, out)
 }

--- a/csv.go
+++ b/csv.go
@@ -64,53 +64,52 @@ func getCSVReader(in io.Reader) *csv.Reader {
 // Marshal functions
 
 // MarshalFile saves the interface as CSV in the file.
-func MarshalFile(in interface{}, file *os.File) (err error) {
-	return Marshal(in, file)
+func MarshalFile(in interface{}, file *os.File, delim rune) (err error) {
+	return Marshal(in, delim, file)
 }
 
 // MarshalString returns the CSV string from the interface.
-func MarshalString(in interface{}) (out string, err error) {
+func MarshalString(in interface{}, delim rune) (out string, err error) {
 	bufferString := bytes.NewBufferString(out)
-	if err := Marshal(in, bufferString); err != nil {
+	if err := Marshal(in, delim, bufferString); err != nil {
 		return "", err
 	}
 	return bufferString.String(), nil
 }
 
 // MarshalBytes returns the CSV bytes from the interface.
-func MarshalBytes(in interface{}) (out []byte, err error) {
+func MarshalBytes(in interface{}, delim rune) (out []byte, err error) {
 	bufferString := bytes.NewBuffer(out)
-	if err := Marshal(in, bufferString); err != nil {
+	if err := Marshal(in, delim, bufferString); err != nil {
 		return nil, err
 	}
 	return bufferString.Bytes(), nil
 }
 
 // Marshal returns the CSV in writer from the interface.
-func Marshal(in interface{}, out io.Writer) (err error) {
-	return newEncoder(out).writeTo(in)
+func Marshal(in interface{}, delim rune, out io.Writer) (err error) {
+	return newEncoder(out, delim).writeTo(in)
 }
 
 // --------------------------------------------------------------------------
 // Unmarshal functions
 
 // UnmarshalFile parses the CSV from the file in the interface.
-func UnmarshalFile(in *os.File, out interface{}) (err error) {
-	return Unmarshal(in, out)
+func UnmarshalFile(in *os.File, delim rune, out interface{}) (err error) {
+	return Unmarshal(in, delim, out)
 }
 
 // UnmarshalString parses the CSV from the string in the interface.
-func UnmarshalString(in string, out interface{}) (err error) {
-	return Unmarshal(strings.NewReader(in), out)
+func UnmarshalString(in string, delim rune, out interface{}) (err error) {
+	return Unmarshal(strings.NewReader(in), delim, out)
 }
 
 // UnmarshalBytes parses the CSV from the bytes in the interface.
-func UnmarshalBytes(in []byte, out interface{}) (err error) {
-	return Unmarshal(bytes.NewReader(in), out)
+func UnmarshalBytes(in []byte, delim rune, out interface{}) (err error) {
+	return Unmarshal(bytes.NewReader(in), delim, out)
 }
 
 // Unmarshal parses the CSV from the reader in the interface.
-func Unmarshal(in io.Reader, out interface{}) (err error) {
-	return newDecoder(in).readTo(out)
+func Unmarshal(in io.Reader, delim rune, out interface{}) (err error) {
+	return newDecoder(in, delim).readTo(out)
 }
-

--- a/decode.go
+++ b/decode.go
@@ -40,6 +40,9 @@ func (decode *decoder) readTo(out interface{}) error {
 				}
 			}
 		} else {
+			if len(outInnerStructInfo.Fields) != len(csvHeadersLabels) {
+				return fmt.Errorf("not all struct tags were matched to a csv header")
+			}
 			outInner := decode.createNewOutInner(outInnerWasPointer, outInnerType)
 			for j, csvColumnContent := range csvRow {
 				if fieldInfo, ok := csvHeadersLabels[j]; ok { // Position found accordingly to header name

--- a/decode.go
+++ b/decode.go
@@ -16,18 +16,18 @@ func newDecoder(in io.Reader) *decoder {
 
 func (decode *decoder) readTo(out interface{}) error {
 	outValue, outType := getConcreteReflectValueAndType(out) // Get the concrete type (not pointer) (Slice<?> or Array<?>)
-	if err := decode.ensureOutType(outType); err != nil {
+	if err := ensureOutType(outType); err != nil {
 		return err
 	}
 	outInnerWasPointer, outInnerType := getConcreteContainerInnerType(outType) // Get the concrete inner type (not pointer) (Container<"?">)
-	if err := decode.ensureOutInnerType(outInnerType); err != nil {
+	if err := ensureOutInnerType(outInnerType); err != nil {
 		return err
 	}
 	csvRows, err := decode.getCSVRows() // Get the CSV csvRows
 	if err != nil {
 		return err
 	}
-	if err := decode.ensureOutCapacity(&outValue, len(csvRows)); err != nil { // Ensure the container is big enough to hold the CSV content
+	if err := ensureOutCapacity(&outValue, len(csvRows)); err != nil { // Ensure the container is big enough to hold the CSV content
 		return err
 	}
 	outInnerStructInfo := getStructInfo(outInnerType)                            // Get the inner struct info to get CSV annotations
@@ -35,7 +35,7 @@ func (decode *decoder) readTo(out interface{}) error {
 	for i, csvRow := range csvRows {                                             // Iterate over csv rows
 		if i == 0 { // First line of CSV is the header line
 			for j, csvColumnHeader := range csvRow {
-				if fieldInfo := decode.getCSVFieldPosition(csvColumnHeader, outInnerStructInfo); fieldInfo != nil {
+				if fieldInfo := getCSVFieldPosition(csvColumnHeader, outInnerStructInfo); fieldInfo != nil {
 					csvHeadersLabels[j] = fieldInfo
 				}
 			}
@@ -43,10 +43,10 @@ func (decode *decoder) readTo(out interface{}) error {
 			if len(outInnerStructInfo.Fields) != len(csvHeadersLabels) {
 				return fmt.Errorf("not all struct tags were matched to a csv header")
 			}
-			outInner := decode.createNewOutInner(outInnerWasPointer, outInnerType)
+			outInner := createNewOutInner(outInnerWasPointer, outInnerType)
 			for j, csvColumnContent := range csvRow {
 				if fieldInfo, ok := csvHeadersLabels[j]; ok { // Position found accordingly to header name
-					if err := decode.setInnerField(&outInner, outInnerWasPointer, fieldInfo.Num, csvColumnContent); err != nil { // Set field of struct
+					if err := setInnerField(&outInner, outInnerWasPointer, fieldInfo.Num, csvColumnContent); err != nil { // Set field of struct
 						return err
 					}
 				}
@@ -58,7 +58,7 @@ func (decode *decoder) readTo(out interface{}) error {
 }
 
 // Check if the outType is an array or a slice
-func (decode *decoder) ensureOutType(outType reflect.Type) error {
+func ensureOutType(outType reflect.Type) error {
 	switch outType.Kind() {
 	case reflect.Slice:
 		fallthrough
@@ -69,7 +69,7 @@ func (decode *decoder) ensureOutType(outType reflect.Type) error {
 }
 
 // Check if the outInnerType is of type struct
-func (decode *decoder) ensureOutInnerType(outInnerType reflect.Type) error {
+func ensureOutInnerType(outInnerType reflect.Type) error {
 	switch outInnerType.Kind() {
 	case reflect.Struct:
 		return nil
@@ -77,7 +77,7 @@ func (decode *decoder) ensureOutInnerType(outInnerType reflect.Type) error {
 	return fmt.Errorf("cannot use " + outInnerType.String() + ", only struct supported")
 }
 
-func (decode *decoder) ensureOutCapacity(out *reflect.Value, csvLen int) error {
+func ensureOutCapacity(out *reflect.Value, csvLen int) error {
 	switch out.Kind() {
 	case reflect.Array:
 		if out.Len() < csvLen-1 { // Array is not big enough to hold the CSV content (arrays are not addressable)
@@ -93,7 +93,7 @@ func (decode *decoder) ensureOutCapacity(out *reflect.Value, csvLen int) error {
 	return nil
 }
 
-func (decode *decoder) getCSVFieldPosition(key string, structInfo *structInfo) *fieldInfo {
+func getCSVFieldPosition(key string, structInfo *structInfo) *fieldInfo {
 	for _, field := range structInfo.Fields {
 		if field.Key == key {
 			return &field
@@ -102,14 +102,14 @@ func (decode *decoder) getCSVFieldPosition(key string, structInfo *structInfo) *
 	return nil
 }
 
-func (decode *decoder) createNewOutInner(outInnerWasPointer bool, outInnerType reflect.Type) reflect.Value {
+func createNewOutInner(outInnerWasPointer bool, outInnerType reflect.Type) reflect.Value {
 	if outInnerWasPointer {
 		return reflect.New(outInnerType)
 	}
 	return reflect.New(outInnerType).Elem()
 }
 
-func (decode *decoder) setInnerField(outInner *reflect.Value, outInnerWasPointer bool, fieldPosition int, value string) error {
+func setInnerField(outInner *reflect.Value, outInnerWasPointer bool, fieldPosition int, value string) error {
 	if outInnerWasPointer {
 		return setField(outInner.Elem().Field(fieldPosition), value)
 	}

--- a/decode.go
+++ b/decode.go
@@ -7,11 +7,12 @@ import (
 )
 
 type decoder struct {
-	in io.Reader
+	in        io.Reader
+	delimiter rune
 }
 
-func newDecoder(in io.Reader) *decoder {
-	return &decoder{in}
+func newDecoder(in io.Reader, delim rune) *decoder {
+	return &decoder{in, delim}
 }
 
 func (decode *decoder) readTo(out interface{}) error {
@@ -117,5 +118,7 @@ func (decode *decoder) setInnerField(outInner *reflect.Value, outInnerWasPointer
 }
 
 func (decode *decoder) getCSVRows() ([][]string, error) {
-	return getCSVReader(decode.in).ReadAll()
+	r := getCSVReader(decode.in)
+	r.Comma = decode.delimiter
+	return r.ReadAll()
 }

--- a/decode.go
+++ b/decode.go
@@ -47,7 +47,11 @@ func readTo(decoder Decoder, out interface{}) error {
 	if err := ensureOutCapacity(&outValue, len(csvRows)); err != nil { // Ensure the container is big enough to hold the CSV content
 		return err
 	}
-	outInnerStructInfo := getStructInfo(outInnerType)                            // Get the inner struct info to get CSV annotations
+	outInnerStructInfo := getStructInfo(outInnerType) // Get the inner struct info to get CSV annotations
+	if len(outInnerStructInfo.Fields) == 0 {
+		return fmt.Errorf("no csv struct tags found")
+	}
+
 	csvHeadersLabels := make(map[int]*fieldInfo, len(outInnerStructInfo.Fields)) // Used to store the correspondance header <-> position in CSV
 	for i, csvRow := range csvRows {                                             // Iterate over csv rows
 		if i == 0 { // First line of CSV is the header line

--- a/decode.go
+++ b/decode.go
@@ -7,12 +7,11 @@ import (
 )
 
 type decoder struct {
-	in        io.Reader
-	delimiter rune
+	in io.Reader
 }
 
-func newDecoder(in io.Reader, delim rune) *decoder {
-	return &decoder{in, delim}
+func newDecoder(in io.Reader) *decoder {
+	return &decoder{in}
 }
 
 func (decode *decoder) readTo(out interface{}) error {
@@ -118,7 +117,5 @@ func (decode *decoder) setInnerField(outInner *reflect.Value, outInnerWasPointer
 }
 
 func (decode *decoder) getCSVRows() ([][]string, error) {
-	r := getCSVReader(decode.in)
-	r.Comma = decode.delimiter
-	return r.ReadAll()
+	return getCSVReader(decode.in).ReadAll()
 }

--- a/decode.go
+++ b/decode.go
@@ -14,6 +14,10 @@ func newDecoder(in io.Reader) *decoder {
 	return &decoder{in}
 }
 
+func (decode *decoder) getCSVRows() ([][]string, error) {
+	return getCSVReader(decode.in).ReadAll()
+}
+
 func (decode *decoder) readTo(out interface{}) error {
 	outValue, outType := getConcreteReflectValueAndType(out) // Get the concrete type (not pointer) (Slice<?> or Array<?>)
 	if err := ensureOutType(outType); err != nil {
@@ -114,8 +118,4 @@ func setInnerField(outInner *reflect.Value, outInnerWasPointer bool, fieldPositi
 		return setField(outInner.Elem().Field(fieldPosition), value)
 	}
 	return setField(outInner.Field(fieldPosition), value)
-}
-
-func (decode *decoder) getCSVRows() ([][]string, error) {
-	return getCSVReader(decode.in).ReadAll()
 }

--- a/decode.go
+++ b/decode.go
@@ -36,20 +36,15 @@ func maybeMissingStructFields(structInfo []fieldInfo, headers []string) error {
 		return nil
 	}
 
-	tags := map[string]struct{}{}
-	for _, info := range structInfo {
-		tags[info.Key] = struct{}{}
+	headerMap := make(map[string]struct{}, len(headers))
+	for idx := range headers {
+		headerMap[headers[idx]] = struct{}{}
 	}
 
-	for tag := range tags {
-		for _, header := range headers {
-			if tag == header {
-				delete(tags, tag)
-			}
+	for _, info := range structInfo {
+		if _, ok := headerMap[info.Key]; !ok {
+			return fmt.Errorf("found unmatched struct tag %v", info.Key)
 		}
-	}
-	if len(tags) != 0 {
-		return fmt.Errorf("found the following unatched tags: %v", tags)
 	}
 	return nil
 }

--- a/decode_test.go
+++ b/decode_test.go
@@ -1,0 +1,28 @@
+package gocsv
+
+import "testing"
+
+func Test_maybeMissingStructFields(t *testing.T) {
+	structTags := []fieldInfo{
+		{Key: "foo"},
+		{Key: "bar"},
+		{Key: "baz"},
+	}
+	badHeaders := []string{"hi", "mom", "bacon"}
+	goodHeaders := []string{"foo", "bar", "baz"}
+
+	// no tags to match, expect no error
+	if err := maybeMissingStructFields([]fieldInfo{}, goodHeaders); err != nil {
+		t.Fatal(err)
+	}
+
+	// bad headers, expect an error
+	if err := maybeMissingStructFields(structTags, badHeaders); err == nil {
+		t.Fatal("expected an error, but no error found")
+	}
+
+	// good headers, expect no error
+	if err := maybeMissingStructFields(structTags, goodHeaders); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/decode_test.go
+++ b/decode_test.go
@@ -25,4 +25,17 @@ func Test_maybeMissingStructFields(t *testing.T) {
 	if err := maybeMissingStructFields(structTags, goodHeaders); err != nil {
 		t.Fatal(err)
 	}
+
+	// extra headers, but all structtags match; expect no error
+	moarHeaders := append(goodHeaders, "qux", "quux", "corge", "grault")
+	if err := maybeMissingStructFields(structTags, moarHeaders); err != nil {
+		t.Fatal(err)
+	}
+
+	// not all structTags match, but there's plenty o' headers; expect
+	// error
+	mismatchedHeaders := []string{"foo", "qux", "quux", "corgi"}
+	if err := maybeMissingStructFields(structTags, mismatchedHeaders); err == nil {
+		t.Fatal("expected an error, but no error found")
+	}
 }

--- a/encode.go
+++ b/encode.go
@@ -23,7 +23,7 @@ func (encode *encoder) writeTo(in interface{}) error {
 	if err := encode.ensureInInnerType(inInnerType); err != nil {
 		return err
 	}
-	csvWriter := getCSVWriter(encode.out)               // Get the CSV writer
+	csvWriter := getCSVWriter(encode.out)           // Get the CSV writer
 	inInnerStructInfo := getStructInfo(inInnerType) // Get the inner struct info to get CSV annotations
 	csvHeadersLabels := make([]string, len(inInnerStructInfo.Fields))
 	for i, fieldInfo := range inInnerStructInfo.Fields { // Used to write the header (first line) in CSV
@@ -43,7 +43,7 @@ func (encode *encoder) writeTo(in interface{}) error {
 		csvWriter.Write(csvHeadersLabels)
 	}
 	csvWriter.Flush()
-	return nil
+	return csvWriter.Error()
 }
 
 // Check if the inType is an array or a slice

--- a/encode.go
+++ b/encode.go
@@ -7,11 +7,12 @@ import (
 )
 
 type encoder struct {
-	out io.Writer
+	out       io.Writer
+	delimiter rune
 }
 
-func newEncoder(out io.Writer) *encoder {
-	return &encoder{out}
+func newEncoder(out io.Writer, delim rune) *encoder {
+	return &encoder{out, delim}
 }
 
 func (encode *encoder) writeTo(in interface{}) error {

--- a/encode.go
+++ b/encode.go
@@ -7,12 +7,11 @@ import (
 )
 
 type encoder struct {
-	out       io.Writer
-	delimiter rune
+	out io.Writer
 }
 
-func newEncoder(out io.Writer, delim rune) *encoder {
-	return &encoder{out, delim}
+func newEncoder(out io.Writer) *encoder {
+	return &encoder{out}
 }
 
 func (encode *encoder) writeTo(in interface{}) error {

--- a/encode.go
+++ b/encode.go
@@ -16,11 +16,11 @@ func newEncoder(out io.Writer) *encoder {
 
 func (encode *encoder) writeTo(in interface{}) error {
 	inValue, inType := getConcreteReflectValueAndType(in) // Get the concrete type (not pointer) (Slice<?> or Array<?>)
-	if err := encode.ensureInType(inType); err != nil {
+	if err := ensureInType(inType); err != nil {
 		return err
 	}
 	inInnerWasPointer, inInnerType := getConcreteContainerInnerType(inType) // Get the concrete inner type (not pointer) (Container<"?">)
-	if err := encode.ensureInInnerType(inInnerType); err != nil {
+	if err := ensureInInnerType(inInnerType); err != nil {
 		return err
 	}
 	csvWriter := getCSVWriter(encode.out)           // Get the CSV writer
@@ -34,7 +34,7 @@ func (encode *encoder) writeTo(in interface{}) error {
 	for i := 0; i < inLen; i++ { // Iterate over container rows
 		for j, fieldInfo := range inInnerStructInfo.Fields {
 			csvHeadersLabels[j] = ""
-			inInnerFieldValue, err := encode.getInnerField(inValue.Index(i), inInnerWasPointer, fieldInfo.Num) // Get the correct field header <-> position
+			inInnerFieldValue, err := getInnerField(inValue.Index(i), inInnerWasPointer, fieldInfo.Num) // Get the correct field header <-> position
 			if err != nil {
 				return err
 			}
@@ -47,7 +47,7 @@ func (encode *encoder) writeTo(in interface{}) error {
 }
 
 // Check if the inType is an array or a slice
-func (encode *encoder) ensureInType(outType reflect.Type) error {
+func ensureInType(outType reflect.Type) error {
 	switch outType.Kind() {
 	case reflect.Slice:
 		fallthrough
@@ -58,7 +58,7 @@ func (encode *encoder) ensureInType(outType reflect.Type) error {
 }
 
 // Check if the inInnerType is of type struct
-func (encode *encoder) ensureInInnerType(outInnerType reflect.Type) error {
+func ensureInInnerType(outInnerType reflect.Type) error {
 	switch outInnerType.Kind() {
 	case reflect.Struct:
 		return nil
@@ -66,7 +66,7 @@ func (encode *encoder) ensureInInnerType(outInnerType reflect.Type) error {
 	return fmt.Errorf("cannot use " + outInnerType.String() + ", only struct supported")
 }
 
-func (encode *encoder) getInnerField(outInner reflect.Value, outInnerWasPointer bool, fieldPosition int) (string, error) {
+func getInnerField(outInner reflect.Value, outInnerWasPointer bool, fieldPosition int) (string, error) {
 	if outInnerWasPointer {
 		return getFieldAsString(outInner.Elem().Field(fieldPosition))
 	}


### PR DESCRIPTION
This partially addresses: https://clypdinc.atlassian.net/browse/MAIN-11864

This patch-set updates clypd's fork of gocsv to do two things
- yell if there's a struct-tag defined in go didn't get matched with a header in csv
- allow custom delimiters when parsing csvs

What's left to do still to resolve MAIN-11864 is to
- vendor clyphub/gocsv into clyphub/gillnet
- update tests in clyphub/gillnet that use gocsv
- rm previously vendored gocarina/gocsv

I will issue a different pull request in the clyphub/gillnet repo once these changes have landed.
