### PR TITLE
Support for embedded structs

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -88,7 +88,7 @@ func readTo(decoder Decoder, out interface{}) error {
 		outInner := createNewOutInner(outInnerWasPointer, outInnerType)
 		for j, csvColumnContent := range csvRow {
 			if fieldInfo, ok := csvHeadersLabels[j]; ok { // Position found accordingly to header name
-				if err := setInnerField(&outInner, outInnerWasPointer, fieldInfo.Num, csvColumnContent); err != nil { // Set field of struct
+				if err := setInnerField(&outInner, outInnerWasPointer, fieldInfo.IndexChain, csvColumnContent); err != nil { // Set field of struct
 					return err
 				}
 			}
@@ -150,9 +150,10 @@ func createNewOutInner(outInnerWasPointer bool, outInnerType reflect.Type) refle
 	return reflect.New(outInnerType).Elem()
 }
 
-func setInnerField(outInner *reflect.Value, outInnerWasPointer bool, fieldPosition int, value string) error {
+func setInnerField(outInner *reflect.Value, outInnerWasPointer bool, index []int, value string) error {
+	oi := *outInner
 	if outInnerWasPointer {
-		return setField(outInner.Elem().Field(fieldPosition), value)
+		oi = outInner.Elem()
 	}
-	return setField(outInner.Field(fieldPosition), value)
+	return setField(oi.FieldByIndex(index), value)
 }

--- a/decode_test.go
+++ b/decode_test.go
@@ -64,3 +64,48 @@ e,3,b`)
 		t.Fatalf("expected second sample %v, got %v", expected, samples[1])
 	}
 }
+
+func Test_readTo_complex_embed(t *testing.T) {
+	b := bytes.NewBufferString(`first,foo,BAR,Baz,last,abc
+aa,bb,11,cc,dd,ee
+ff,gg,22,hh,ii,jj`)
+	d := csvDecoder{csv.NewReader(b)}
+
+	var samples []SkipFieldSample
+	if err := readTo(d, &samples); err != nil {
+		t.Fatal(err)
+	}
+	if len(samples) != 2 {
+		t.Fatalf("expected 2 sample instances, got %d", len(samples))
+	}
+	expected := SkipFieldSample{
+		EmbedSample: EmbedSample{
+			Qux: "aa",
+			Sample: Sample{
+				Foo: "bb",
+				Bar: 11,
+				Baz: "cc",
+			},
+			Quux: "dd",
+		},
+		Corge: "ee",
+	}
+	if expected != samples[0] {
+		t.Fatalf("expected first sample %v, got %v", expected, samples[0])
+	}
+	expected = SkipFieldSample{
+		EmbedSample: EmbedSample{
+			Qux: "ff",
+			Sample: Sample{
+				Foo: "gg",
+				Bar: 22,
+				Baz: "hh",
+			},
+			Quux: "ii",
+		},
+		Corge: "jj",
+	}
+	if expected != samples[1] {
+		t.Fatalf("expected first sample %v, got %v", expected, samples[1])
+	}
+}

--- a/decode_test.go
+++ b/decode_test.go
@@ -1,5 +1,7 @@
 package gocsv
 
+import "bytes"
+import "encoding/csv"
 import "testing"
 
 func Test_maybeMissingStructFields(t *testing.T) {
@@ -37,5 +39,28 @@ func Test_maybeMissingStructFields(t *testing.T) {
 	mismatchedHeaders := []string{"foo", "qux", "quux", "corgi"}
 	if err := maybeMissingStructFields(structTags, mismatchedHeaders); err == nil {
 		t.Fatal("expected an error, but no error found")
+	}
+}
+
+func Test_readTo(t *testing.T) {
+	b := bytes.NewBufferString(`foo,BAR,Baz
+f,1,baz
+e,3,b`)
+	d := csvDecoder{csv.NewReader(b)}
+
+	var samples []Sample
+	if err := readTo(d, &samples); err != nil {
+		t.Fatal(err)
+	}
+	if len(samples) != 2 {
+		t.Fatalf("expected 2 sample instances, got %d", len(samples))
+	}
+	expected := Sample{Foo: "f", Bar: 1, Baz: "baz"}
+	if expected != samples[0] {
+		t.Fatalf("expected first sample %v, got %v", expected, samples[0])
+	}
+	expected = Sample{Foo: "e", Bar: 3, Baz: "b"}
+	if expected != samples[1] {
+		t.Fatalf("expected second sample %v, got %v", expected, samples[1])
 	}
 }

--- a/encode.go
+++ b/encode.go
@@ -36,7 +36,7 @@ func writeTo(writer *csv.Writer, in interface{}) error {
 	for i := 0; i < inLen; i++ { // Iterate over container rows
 		for j, fieldInfo := range inInnerStructInfo.Fields {
 			csvHeadersLabels[j] = ""
-			inInnerFieldValue, err := getInnerField(inValue.Index(i), inInnerWasPointer, fieldInfo.Num) // Get the correct field header <-> position
+			inInnerFieldValue, err := getInnerField(inValue.Index(i), inInnerWasPointer, fieldInfo.IndexChain) // Get the correct field header <-> position
 			if err != nil {
 				return err
 			}
@@ -70,9 +70,10 @@ func ensureInInnerType(outInnerType reflect.Type) error {
 	return fmt.Errorf("cannot use " + outInnerType.String() + ", only struct supported")
 }
 
-func getInnerField(outInner reflect.Value, outInnerWasPointer bool, fieldPosition int) (string, error) {
+func getInnerField(outInner reflect.Value, outInnerWasPointer bool, index []int) (string, error) {
+	oi := outInner
 	if outInnerWasPointer {
-		return getFieldAsString(outInner.Elem().Field(fieldPosition))
+		oi = outInner.Elem()
 	}
-	return getFieldAsString(outInner.Field(fieldPosition))
+	return getFieldAsString(oi.FieldByIndex(index))
 }

--- a/encode_test.go
+++ b/encode_test.go
@@ -1,0 +1,48 @@
+package gocsv
+
+import (
+	"bytes"
+	"encoding/csv"
+	"testing"
+)
+
+type Sample struct {
+	Foo string `csv:"foo"`
+	Bar int    `csv:"BAR"`
+	Baz string `csv:"Baz"`
+}
+
+func assertLine(t *testing.T, expected, actual []string) {
+	if len(expected) != len(actual) {
+		t.Fatalf("line length mismatch between expected: %d and actual: %d", len(expected), len(actual))
+	}
+	for i := range expected {
+		if expected[i] != actual[i] {
+			t.Fatalf("mismatch on field %d: %s != %s", i, expected[i], actual[i])
+		}
+
+	}
+}
+
+func Test_writeTo(t *testing.T) {
+	b := bytes.Buffer{}
+	w := csv.NewWriter(&b)
+	s := []Sample{
+		{Foo: "f", Bar: 1, Baz: "baz"},
+		{Foo: "e", Bar: 3, Baz: "b"},
+	}
+	if err := writeTo(w, s); err != nil {
+		t.Fatal(err)
+	}
+
+	lines, err := csv.NewReader(&b).ReadAll()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(lines) != 3 {
+		t.Fatalf("expected 3 lines, got %d", len(lines))
+	}
+	assertLine(t, []string{"foo", "BAR", "Baz"}, lines[0])
+	assertLine(t, []string{"f", "1", "baz"}, lines[1])
+	assertLine(t, []string{"e", "3", "b"}, lines[2])
+}

--- a/reflect.go
+++ b/reflect.go
@@ -11,13 +11,11 @@ import (
 
 type structInfo struct {
 	Fields []fieldInfo
-	Zero   reflect.Value
 }
 
 type fieldInfo struct {
-	Key       string
-	Num       int
-	OmitEmpty bool
+	Key string
+	Num int
 }
 
 var structMap = make(map[reflect.Type]*structInfo)
@@ -41,9 +39,7 @@ func getStructInfo(rType reflect.Type) *structInfo {
 		fieldTag := field.Tag.Get("csv")
 		fieldTags := strings.Split(fieldTag, ",")
 		for _, fieldTagEntry := range fieldTags {
-			if fieldTagEntry == "omitempty" {
-				fieldInfo.OmitEmpty = true
-			} else {
+			if fieldTagEntry != "omitempty" {
 				fieldTag = fieldTagEntry
 			}
 		}
@@ -56,7 +52,7 @@ func getStructInfo(rType reflect.Type) *structInfo {
 		}
 		fieldsList = append(fieldsList, fieldInfo)
 	}
-	stInfo = &structInfo{fieldsList, reflect.New(rType).Elem()}
+	stInfo = &structInfo{fieldsList}
 	return stInfo
 }
 

--- a/reflect.go
+++ b/reflect.go
@@ -28,6 +28,12 @@ func getStructInfo(rType reflect.Type) *structInfo {
 	if ok {
 		return stInfo
 	}
+	fieldsList := getFieldInfos(rType)
+	stInfo = &structInfo{fieldsList}
+	return stInfo
+}
+
+func getFieldInfos(rType reflect.Type) []fieldInfo {
 	fieldsCount := rType.NumField()
 	fieldsList := make([]fieldInfo, 0, fieldsCount)
 	for i := 0; i < fieldsCount; i++ {
@@ -52,8 +58,7 @@ func getStructInfo(rType reflect.Type) *structInfo {
 		}
 		fieldsList = append(fieldsList, fieldInfo)
 	}
-	stInfo = &structInfo{fieldsList}
-	return stInfo
+	return fieldsList
 }
 
 func getConcreteContainerInnerType(in reflect.Type) (inInnerWasPointer bool, inInnerType reflect.Type) {

--- a/sample_structs_test.go
+++ b/sample_structs_test.go
@@ -1,0 +1,20 @@
+package gocsv
+
+type Sample struct {
+	Foo string `csv:"foo"`
+	Bar int    `csv:"BAR"`
+	Baz string `csv:"Baz"`
+}
+
+type EmbedSample struct {
+	Qux string `csv:"first"`
+	Sample
+	Ignore string `csv:"-"`
+	Quux   string `csv:"last"`
+}
+
+type SkipFieldSample struct {
+	EmbedSample
+	MoreIgnore string `csv:"-"`
+	Corge      string `csv:"abc"`
+}


### PR DESCRIPTION
This feature has become necessary for working with large, repetitive structs with only minor differences. I would like to extract and embed the common elements.
