### PR TITLE
Add support for multiple struct tags for CSV decoding

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -9,7 +9,7 @@ import (
 )
 
 var (
- 	ErrEmptyCSV = errors.New("empty csv file given")
+	ErrEmptyCSV = errors.New("empty csv file given")
 )
 
 type Decoder interface {

--- a/decode.go
+++ b/decode.go
@@ -47,8 +47,15 @@ func maybeMissingStructFields(structInfo []fieldInfo, headers []string) error {
 	}
 
 	for _, info := range structInfo {
-		if _, ok := headerMap[info.Key]; !ok {
-			return fmt.Errorf("found unmatched struct tag %v", info.Key)
+		found := false
+		for _, key := range info.keys {
+			if _, ok := headerMap[key]; ok {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("found unmatched struct field with tags %v", info.keys)
 		}
 	}
 	return nil
@@ -149,7 +156,7 @@ func ensureOutCapacity(out *reflect.Value, csvLen int) error {
 
 func getCSVFieldPosition(key string, structInfo *structInfo) *fieldInfo {
 	for _, field := range structInfo.Fields {
-		if field.Key == key {
+		if field.matchesKey(key) {
 			return &field
 		}
 	}

--- a/decode.go
+++ b/decode.go
@@ -94,8 +94,9 @@ func readTo(decoder Decoder, out interface{}) error {
 			csvHeadersLabels[i] = fieldInfo
 		}
 	}
-	if err := maybeMissingStructFields(outInnerStructInfo.Fields, headers); err != nil {
-		if FailIfUnmatchedStructTags {
+
+	if FailIfUnmatchedStructTags {
+		if err := maybeMissingStructFields(outInnerStructInfo.Fields, headers); err != nil {
 			return err
 		}
 	}

--- a/decode_test.go
+++ b/decode_test.go
@@ -55,13 +55,35 @@ e,BAD_INPUT,b`)
 	default:
 		t.Fatalf("incorrect error type: %T", err)
 	}
+}
 
+func Test_readTo_multipleTags(t *testing.T) {
+	b := bytes.NewBufferString(`Foo,bar
+abc,123
+def,234`)
+	d := &decoder{in: b}
+
+	var samples []MultiTagSample
+	if err := readTo(d, &samples); err != nil {
+		t.Fatal(err)
+	}
+	if len(samples) != 2 {
+		t.Fatalf("expected 2 sample instances, got %d", len(samples))
+	}
+	expected := MultiTagSample{Foo: "abc", Bar: 123}
+	if expected != samples[0] {
+		t.Fatalf("expected first sample %v, got %v", expected, samples[0])
+	}
+	expected = MultiTagSample{Foo: "def", Bar: 234}
+	if expected != samples[1] {
+		t.Fatalf("expected second sample %v, got %v", expected, samples[1])
+	}
 }
 
 func Test_readTo_complex_embed(t *testing.T) {
 	defer resetFailIfUnmatchedStructTags(FailIfUnmatchedStructTags)
 	FailIfUnmatchedStructTags = false
-	
+
 	b := bytes.NewBufferString(`first,foo,BAR,Baz,last,abc
 aa,bb,11,cc,dd,ee
 ff,gg,22,hh,ii,jj`)
@@ -108,9 +130,9 @@ ff,gg,22,hh,ii,jj`)
 
 func Test_maybeMissingStructFields(t *testing.T) {
 	structTags := []fieldInfo{
-		{Key: "foo"},
-		{Key: "bar"},
-		{Key: "baz"},
+		{keys: []string{"foo"}},
+		{keys: []string{"bar"}},
+		{keys: []string{"baz"}},
 	}
 	badHeaders := []string{"hi", "mom", "bacon"}
 	goodHeaders := []string{"foo", "bar", "baz"}

--- a/encode.go
+++ b/encode.go
@@ -27,7 +27,7 @@ func writeTo(writer *csv.Writer, in interface{}) error {
 	inInnerStructInfo := getStructInfo(inInnerType) // Get the inner struct info to get CSV annotations
 	csvHeadersLabels := make([]string, len(inInnerStructInfo.Fields))
 	for i, fieldInfo := range inInnerStructInfo.Fields { // Used to write the header (first line) in CSV
-		csvHeadersLabels[i] = fieldInfo.Key
+		csvHeadersLabels[i] = fieldInfo.getFirstKey()
 	}
 	if err := writer.Write(csvHeadersLabels); err != nil {
 		return err

--- a/encode_test.go
+++ b/encode_test.go
@@ -42,6 +42,30 @@ func Test_writeTo(t *testing.T) {
 	assertLine(t, []string{"e", "3", "b", "0.46153846"}, lines[2])
 }
 
+func Test_writeTo_multipleTags(t *testing.T) {
+	b := bytes.Buffer{}
+	e := &encoder{out: &b}
+	s := []MultiTagSample{
+		{Foo: "abc", Bar: 123},
+		{Foo: "def", Bar: 234},
+	}
+	if err := writeTo(csv.NewWriter(e.out), s); err != nil {
+		t.Fatal(err)
+	}
+
+	lines, err := csv.NewReader(&b).ReadAll()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(lines) != 3 {
+		t.Fatalf("expected 3 lines, got %d", len(lines))
+	}
+	// the first tag for each field is the encoding CSV header
+	assertLine(t, []string{"foo", "bar"}, lines[0])
+	assertLine(t, []string{"abc", "123"}, lines[1])
+	assertLine(t, []string{"def", "234"}, lines[2])
+}
+
 func Test_writeTo_embed(t *testing.T) {
 	b := bytes.Buffer{}
 	e := &encoder{out: &b}

--- a/sample_structs_test.go
+++ b/sample_structs_test.go
@@ -20,3 +20,8 @@ type SkipFieldSample struct {
 	MoreIgnore string `csv:"-"`
 	Corge      string `csv:"abc"`
 }
+
+type MultiTagSample struct {
+	Foo string `csv:"foo,Foo,FOO"`
+	Bar int    `csv:"bar,BAR"`
+}


### PR DESCRIPTION
This enables backwards-compatible CSV header renames.

Encoding uses the first tag in the list.
