### PR TITLE
MAIN-22856 - Disable base resolution in int parsing. Assume base 10.

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -523,3 +523,37 @@ e`)
 		t.Fatal("Something went wrong")
 	}
 }
+
+func Test_ZeroPrefixedIntegerUnmarshal(t *testing.T) {
+	defer resetFailIfUnmatchedStructTags(FailIfUnmatchedStructTags)
+	FailIfUnmatchedStructTags = false
+	b := bytes.NewBufferString(`foo,BAR
+a,006`)
+	d := &decoder{in: b}
+
+	var samples []Sample
+	if err := readTo(d, &samples); err != nil {
+		t.Fatal(err)
+	}
+	if len(samples) != 1 {
+		t.Fatalf("expected 1 sample instance, got %d", len(samples))
+	}
+	if samples[0].Bar != 6 {
+		t.Fatal("expected Bar=6 got Bar=%d", samples[0].Bar)
+	}
+
+	b = bytes.NewBufferString(`foo,BAR
+a,08`)
+	d = &decoder{in: b}
+
+	samples = []Sample{}
+	if err := readTo(d, &samples); err != nil {
+		t.Fatal(err)
+	}
+	if len(samples) != 1 {
+		t.Fatalf("expected 1 sample instance, got %d", len(samples))
+	}
+	if samples[0].Bar != 8 {
+		t.Fatal("expected Bar=8 got Bar=%d", samples[0].Bar)
+	}
+}

--- a/types.go
+++ b/types.go
@@ -130,7 +130,7 @@ func toInt(in interface{}) (int64, error) {
 		if s == "" {
 			return 0, nil
 		}
-		return strconv.ParseInt(s, 0, 64)
+		return strconv.ParseInt(s, 10, 64)
 	case reflect.Bool:
 		if inValue.Bool() {
 			return 1, nil


### PR DESCRIPTION
Zero Base results in ParseInt resolving the base by examining a prefix:
https://golang.org/src/strconv/atoi.go?s=3604:3671#L60

This is not desirable for how we use gocsv, since we do not have a use
case for non-base10 CSV unmarshalling. Leaving resolution in place
breaks in cases where gocsv is used to ingest data that contains
zero-prefixed integers that are intended to be base10.