### PR TITLE
Speed up custom type (un)marshalling

### DIFF
--- a/types.go
+++ b/types.go
@@ -381,16 +381,19 @@ func getFieldAsString(field reflect.Value) (str string, err error) {
 func unmarshall(field reflect.Value, value string) error {
 	dupField := field
 	unMarshallIt := func(finalField reflect.Value) error {
-		if finalField.CanInterface() && finalField.Type().Implements(unMarshallerType) {
-			if err := finalField.Interface().(TypeUnmarshaller).UnmarshalCSV(value); err != nil {
-				return err
+		if finalField.CanInterface() {
+			fieldIface := finalField.Interface()
+
+			fieldTypeUnmarshaller, ok := fieldIface.(TypeUnmarshaller)
+			if ok {
+				return fieldTypeUnmarshaller.UnmarshalCSV(value)
 			}
-			return nil
-		} else if finalField.CanInterface() && finalField.Type().Implements(textUnMarshalerType) { // Otherwise try to use TextMarshaller
-			if err := finalField.Interface().(encoding.TextUnmarshaler).UnmarshalText([]byte(value)); err != nil {
-				return err
+
+			// Otherwise try to use TextUnmarshaler
+			fieldTextUnmarshaler, ok := fieldIface.(encoding.TextUnmarshaler)
+			if ok {
+				return fieldTextUnmarshaler.UnmarshalText([]byte(value))
 			}
-			return nil
 		}
 
 		return NoUnmarshalFuncError{"No known conversion from string to " + field.Type().String() + ", " + field.Type().String() + " does not implement TypeUnmarshaller"}

--- a/types.go
+++ b/types.go
@@ -415,13 +415,27 @@ func unmarshall(field reflect.Value, value string) error {
 func marshall(field reflect.Value) (value string, err error) {
 	dupField := field
 	marshallIt := func(finalField reflect.Value) (string, error) {
-		if finalField.CanInterface() && finalField.Type().Implements(marshallerType) { // Use TypeMarshaller when possible
-			return finalField.Interface().(TypeMarshaller).MarshalCSV()
-		} else if finalField.CanInterface() && finalField.Type().Implements(stringerType) { // Otherwise try to use Stringer
-			return finalField.Interface().(Stringer).String(), nil
-		} else if finalField.CanInterface() && finalField.Type().Implements(textMarshalerType) { // Otherwise try to use TextMarshaller
-			text, err := finalField.Interface().(encoding.TextMarshaler).MarshalText()
-			return string(text), err
+		if finalField.CanInterface() {
+			fieldIface := finalField.Interface()
+
+			// Use TypeMarshaller when possible
+			fieldTypeMarhaller, ok := fieldIface.(TypeMarshaller)
+			if ok {
+				return fieldTypeMarhaller.MarshalCSV()
+			}
+
+			// Otherwise try to use Stringer
+			fieldStringer, ok := fieldIface.(Stringer)
+			if ok {
+				return fieldStringer.String(), nil
+			}
+
+			// Otherwise try to use TextMarshaller
+			fieldTextMarshaler, ok := fieldIface.(encoding.TextMarshaler)
+			if ok {
+				text, err := fieldTextMarshaler.MarshalText()
+				return string(text), err
+			}
 		}
 
 		return value, NoMarshalFuncError{"No known conversion from " + field.Type().String() + " to string, " + field.Type().String() + " does not implement TypeMarshaller nor Stringer"}

--- a/types_test.go
+++ b/types_test.go
@@ -1,0 +1,44 @@
+package gocsv
+
+import (
+	"reflect"
+	"testing"
+)
+
+type sampleTypeUnmarshaller struct {
+	val string
+}
+
+func (s *sampleTypeUnmarshaller) UnmarshalCSV(val string) error {
+	s.val = val
+	return nil
+}
+
+type sampleTextUnmarshaller struct {
+	val []byte
+}
+
+func (s *sampleTextUnmarshaller) UnmarshalText(text []byte) error {
+	s.val = text
+	return nil
+}
+
+func Benchmark_unmarshall_TypeUnmarshaller(b *testing.B) {
+	sample := sampleTypeUnmarshaller{}
+	val := reflect.ValueOf(&sample)
+	for n := 0; n < b.N; n++ {
+		if err := unmarshall(val, "foo"); err != nil {
+			b.Fatalf("unmarshall error: %s", err.Error())
+		}
+	}
+}
+
+func Benchmark_unmarshall_TextUnmarshaller(b *testing.B) {
+	sample := sampleTextUnmarshaller{}
+	val := reflect.ValueOf(&sample)
+	for n := 0; n < b.N; n++ {
+		if err := unmarshall(val, "foo"); err != nil {
+			b.Fatalf("unmarshall error: %s", err.Error())
+		}
+	}
+}

--- a/types_test.go
+++ b/types_test.go
@@ -14,6 +14,10 @@ func (s *sampleTypeUnmarshaller) UnmarshalCSV(val string) error {
 	return nil
 }
 
+func (s sampleTypeUnmarshaller) MarshalCSV() (string, error) {
+	return s.val, nil
+}
+
 type sampleTextUnmarshaller struct {
 	val []byte
 }
@@ -21,6 +25,16 @@ type sampleTextUnmarshaller struct {
 func (s *sampleTextUnmarshaller) UnmarshalText(text []byte) error {
 	s.val = text
 	return nil
+}
+
+func (s sampleTextUnmarshaller) MarshalText() ([]byte, error) {
+	return s.val, nil
+}
+
+type sampleStringer string
+
+func (s sampleStringer) String() string {
+	return string(s)
 }
 
 func Benchmark_unmarshall_TypeUnmarshaller(b *testing.B) {
@@ -39,6 +53,39 @@ func Benchmark_unmarshall_TextUnmarshaller(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		if err := unmarshall(val, "foo"); err != nil {
 			b.Fatalf("unmarshall error: %s", err.Error())
+		}
+	}
+}
+
+func Benchmark_marshall_TypeMarshaller(b *testing.B) {
+	sample := sampleTypeUnmarshaller{"foo"}
+	val := reflect.ValueOf(&sample)
+	for n := 0; n < b.N; n++ {
+		_, err := marshall(val)
+		if err != nil {
+			b.Fatalf("marshall error: %s", err.Error())
+		}
+	}
+}
+
+func Benchmark_marshall_TextMarshaller(b *testing.B) {
+	sample := sampleTextUnmarshaller{[]byte("foo")}
+	val := reflect.ValueOf(&sample)
+	for n := 0; n < b.N; n++ {
+		_, err := marshall(val)
+		if err != nil {
+			b.Fatalf("marshall error: %s", err.Error())
+		}
+	}
+}
+
+func Benchmark_marshall_Stringer(b *testing.B) {
+	sample := sampleStringer("foo")
+	val := reflect.ValueOf(&sample)
+	for n := 0; n < b.N; n++ {
+		_, err := marshall(val)
+		if err != nil {
+			b.Fatalf("marshall error: %s", err.Error())
 		}
 	}
 }


### PR DESCRIPTION
Replacing the [Type.Implements](https://golang.org/pkg/reflect/#Type) calls with a type assertion allows Go to cache the result of these evaluations, which leads to about a ~40% speed-up when unmarshalling into a custom TypeUnmarshaller. See https://stackoverflow.com/questions/46837485/why-is-reflect-type-implements-so-much-slower-than-a-type-assertion for more background.