### PR TITLE
Main 28106

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -86,7 +86,7 @@ func mismatchStructFields(structInfo []fieldInfo, headers []string) []string {
 				break
 			}
 		}
-		if !found {
+		if !found && !info.omitEmpty {
 			missing = append(missing, info.keys...)
 		}
 	}

--- a/decode_test.go
+++ b/decode_test.go
@@ -217,6 +217,9 @@ func Test_maybeMissingStructFields(t *testing.T) {
 		{keys: []string{"bar"}},
 		{keys: []string{"baz"}},
 	}
+	optionalStructTags := []fieldInfo{
+		{keys: []string{"ham"}, omitEmpty: true},
+	}
 	badHeaders := []string{"hi", "mom", "bacon"}
 	goodHeaders := []string{"foo", "bar", "baz"}
 
@@ -235,9 +238,19 @@ func Test_maybeMissingStructFields(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// good headers, with one omitempty, expect no error
+	if err := maybeMissingStructFields(append(structTags, optionalStructTags...), goodHeaders); err != nil {
+		t.Fatal(err)
+	}
+
 	// extra headers, but all structtags match; expect no error
 	moarHeaders := append(goodHeaders, "qux", "quux", "corge", "grault")
 	if err := maybeMissingStructFields(structTags, moarHeaders); err != nil {
+		t.Fatal(err)
+	}
+
+	// good headers, with one omitempty, expect no error
+	if err := maybeMissingStructFields(append(structTags, optionalStructTags...), append(goodHeaders, "ham")); err != nil {
 		t.Fatal(err)
 	}
 

--- a/decode_test.go
+++ b/decode_test.go
@@ -561,7 +561,7 @@ a,006`)
 		t.Fatalf("expected 1 sample instance, got %d", len(samples))
 	}
 	if samples[0].Bar != 6 {
-		t.Fatal("expected Bar=6 got Bar=%d", samples[0].Bar)
+		t.Fatalf("expected Bar=6 got Bar=%d", samples[0].Bar)
 	}
 
 	b = bytes.NewBufferString(`foo,BAR
@@ -576,7 +576,7 @@ a,08`)
 		t.Fatalf("expected 1 sample instance, got %d", len(samples))
 	}
 	if samples[0].Bar != 8 {
-		t.Fatal("expected Bar=8 got Bar=%d", samples[0].Bar)
+		t.Fatalf("expected Bar=8 got Bar=%d", samples[0].Bar)
 	}
 }
 


### PR DESCRIPTION
current behavior for omitempty is that it handles nullable types appropriately, but still expects that the column header exists.  that's a bit unintuitive, as for example, the encoding/json package treats omitempty as 'dont even care if that field exists', rather than expect the field to exist, but handle the empty/null case appropriately.  update the behavior here to match that of encoding/json, and dont barf if the column header doesn't exist.