### PR TITLE
Fix csv marshaller for marshal chan

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -34,6 +34,15 @@ func writeFromChan(writer *SafeCSVWriter, c <-chan interface{}) error {
 		return err
 	}
 	write := func(val reflect.Value) error {
+		if !val.CanAddr() {
+			// Make an addressable copy
+			//
+			// Admittedly this is a kludge but downstream operations (like reflect.Value.Interface())
+			// require addressability
+			ptr := reflect.New(val.Type())
+			ptr.Elem().Set(val)
+			val = ptr.Elem()
+		}
 		for j, fieldInfo := range inInnerStructInfo.Fields {
 			csvHeadersLabels[j] = ""
 			inInnerFieldValue, err := getInnerField(val, inInnerWasPointer, fieldInfo.IndexChain) // Get the correct field header <-> position

--- a/encode_test.go
+++ b/encode_test.go
@@ -219,7 +219,7 @@ func Test_writeToChan(t *testing.T) {
 			assertLine(t, []string{"foo", "BAR", "Baz", "Quux", "Blah", "SPtr", "Marshaller", "Omit"}, l)
 			continue
 		}
-		assertLine(t, []string{"f", strconv.Itoa(i - 1), "baz" + strconv.Itoa(i-1), strconv.FormatFloat(float64(i-1), 'f', -1, 64), "", "*string", "", ""}, l)
+		assertLine(t, []string{"f", strconv.Itoa(i - 1), "baz" + strconv.Itoa(i-1), strconv.FormatFloat(float64(i-1), 'f', -1, 64), "", "*string", "foo 1", ""}, l)
 	}
 }
 

--- a/encode_test.go
+++ b/encode_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func assertLine(t *testing.T, expected, actual []string) {
+	t.Helper()
 	if len(expected) != len(actual) {
 		t.Fatalf("line length mismatch between expected: %d and actual: %d", len(expected), len(actual))
 	}

--- a/sample_structs_test.go
+++ b/sample_structs_test.go
@@ -1,15 +1,33 @@
 package gocsv
 
-import "time"
+import (
+	"fmt"
+	"time"
+)
+
+type MarshallerStruct struct {
+	Foo string
+	Bar int
+}
+
+func (m MarshallerStruct) MarshalCSV() (string, error) {
+	return fmt.Sprintf("%s %d", m.Foo, m.Bar), nil
+}
+
+func (m MarshallerStruct) UnmarshalCSV(s string) error {
+	_, err := fmt.Sscanf("%s %d", s, &m.Foo, &m.Bar)
+	return err
+}
 
 type Sample struct {
-	Foo  string  `csv:"foo"`
-	Bar  int     `csv:"BAR"`
-	Baz  string  `csv:"Baz"`
-	Frop float64 `csv:"Quux"`
-	Blah *int    `csv:"Blah"`
-	SPtr *string `csv:"SPtr"`
-	Omit *string `csv:"Omit,omitempty"`
+	Foo        string           `csv:"foo"`
+	Bar        int              `csv:"BAR"`
+	Baz        string           `csv:"Baz"`
+	Frop       float64          `csv:"Quux"`
+	Blah       *int             `csv:"Blah"`
+	SPtr       *string          `csv:"SPtr"`
+	Marshaller MarshallerStruct `csv:"Marshaller"`
+	Omit       *string          `csv:"Omit,omitempty"`
 }
 
 type EmbedSample struct {


### PR DESCRIPTION
The commit message for dbd300f lays out the bulk of the issue, so I won't repeat it here.  The context is that I was trying to use MarshalChan in gillnet only to discover that it didn't work as advertised with respect to `broadcast.Date`s.  So, I fixed it.

Please let me know your thoughts on this solution.